### PR TITLE
Adding support for Mongo's multiple update inside Kima Model's put metho...

### DIFF
--- a/library/Kima/Database/Mongo.php
+++ b/library/Kima/Database/Mongo.php
@@ -235,10 +235,14 @@ class Mongo extends ADatabase
                 ? 0
                 : 1;
 
+            $multiple = !empty($options['query']['multiple'])
+                ? true
+                : false;
+
             return $collection->update(
                 $filters,
                 $fields,
-                ['upsert' => true, 'w' => $async]);
+                ['upsert' => true, 'w' => $async, 'multiple' => $multiple]);
         } catch (MongoException $e) {
             Error::set(sprintf(self::ERROR_MONGO_QUERY, $e->getMessage()));
         }

--- a/library/Kima/Model.php
+++ b/library/Kima/Model.php
@@ -142,6 +142,12 @@ abstract class Model
     private $async;
 
     /**
+     * 'Multiple update' flag
+     * @var boolean
+     */
+    private $multiple;
+
+    /**
      * The query string created
      * @var string
      */
@@ -430,6 +436,17 @@ abstract class Model
     }
 
     /**
+     * Sets the 'multiple' flag for (mongo's) multiple update
+     * @param boolean $multiple
+     */
+    public function multiple($multiple)
+    {
+        $this->multiple = $multiple;
+
+        return $this;
+    }
+
+    /**
      * Turns on debug mode
      */
     public function debug()
@@ -469,7 +486,8 @@ abstract class Model
             'order' => $this->order,
             'limit' => $this->limit,
             'start' => $this->start,
-            'async' => $this->async
+            'async' => $this->async,
+            'multiple' => $this->multiple
         ];
     }
 


### PR DESCRIPTION
In order to update multiple records when using MongoDB, the property 'multiple' is added to Kima Model file. That property is checked when performing a mongo update, and added as a parameter to the mongo query.

Usage example:
$model_instance->filter( filter array )->multiple(true)->put( put fields );
