### PR TITLE
Enabling custom language parameters

### DIFF
--- a/library/Kima/Action.php
+++ b/library/Kima/Action.php
@@ -208,7 +208,7 @@ class Action
      * Gets the language required for the current action
      * @param string $handler
      */
-    private function get_language($handler = null, $handler_params = array())
+    private function get_language($handler = null, $handler_params = [])
     {
         $app = Application::get_instance();
 

--- a/library/Kima/Language.php
+++ b/library/Kima/Language.php
@@ -40,7 +40,7 @@ class Language
      * Handler is only set once from kima action
      * @return mixed
      */
-    public static function get_instance($handler = null, $handler_params = array())
+    public static function get_instance($handler = null, $handler_params = [])
     {
         // check if a language source instance was previously set
         if (!is_null(self::$lang_source)) {


### PR DESCRIPTION
Adding support for language handler custom parameters
Required to enable multiple Facebook applications language setup (currently used on tab locale)
