### PR TITLE
Fixed problem on procedure return information [issue #2005]

### DIFF
--- a/library/Kima/Procedure.php
+++ b/library/Kima/Procedure.php
@@ -256,7 +256,7 @@ abstract class Procedure
 
         $this->clear_procedure_params();
 
-        return $result;
+        return $result['objects'];
     }
 
 }


### PR DESCRIPTION
Procedure call function was returned the result as an associative array, this was changed to return the results directly.