### PR TITLE
Removing redirect to http in check_https function

### DIFF
--- a/library/Kima/Prime/Action.php
+++ b/library/Kima/Prime/Action.php
@@ -146,10 +146,7 @@ class Action
             return $is_https ? true : Redirector::https();
         }
 
-        // if we are on https but shouldn't redirect to http
-        if ($is_https && !in_array($this->controller, $https_controllers)) {
-            return Redirector::http();
-        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
Redirect to http is not responsibility of the framework. Because does not permit of easy way, enable https for all pages if the user would like this.