### PR TITLE
Updating datadog-version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=7.1",
         "mongodb/mongodb": "^1.0.0",
-        "datadog/dd-trace": "^0.20.0"
+        "datadog/dd-trace": "0.28.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Updating datadog version that have a breaking change, see: https://github.com/DataDog/dd-trace-php/releases/tag/0.23.0