### PR TITLE
HULI-29759: Updated commit and rollback to check if a transaction is …

### DIFF
--- a/library/Kima/Database/Pdo.php
+++ b/library/Kima/Database/Pdo.php
@@ -293,7 +293,8 @@ final class Pdo implements IDatabase, ITransaction
      */
     public function commit(): bool
     {
-        return $this->get_connection()->commit();
+        $connection = $this->get_connection();
+        return $connection->inTransaction() ? $connection->commit() : false;
     }
 
     /**
@@ -301,7 +302,8 @@ final class Pdo implements IDatabase, ITransaction
      */
     public function rollback(): bool
     {
-        return $this->get_connection()->rollBack();
+        $connection = $this->get_connection();
+        return $connection->inTransaction() ? $connection->rollBack() : false;
     }
 
     /**


### PR DESCRIPTION
…active,  there is stricter validation on transaction handling in PDO causing errors when calling commit() or rollBack() without an active transaction. This resulted in failing tests and unexpected behavior. 